### PR TITLE
Work around an illegal Ada 2012 construct now spotted by the compiler

### DIFF
--- a/source/text/implementation/vss-strings-cursors-iterators-characters.adb
+++ b/source/text/implementation/vss-strings-cursors-iterators-characters.adb
@@ -4,6 +4,8 @@
 --  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 --
 
+pragma Ada_2022;
+
 package body VSS.Strings.Cursors.Iterators.Characters is
 
    use type VSS.Implementation.Referrers.Magic_String_Access;


### PR DESCRIPTION
The construct is the function call in the return statement of Backward, which is illegal per RM 6.4.1(6.4): In a function call, the accessibility level of the actual object for each explicitly aliased parameter shall not be statically deeper than the accessibility level of the master of the call.

The fix would be to make the Self parameter explicitly aliased, but it's a bit painful since the function is overriding.  And it's legal in Ada 2022.